### PR TITLE
Added DiffConfig class with AllowCyclicGraph

### DIFF
--- a/ODiff.Tests/Diff_hash_codes.cs
+++ b/ODiff.Tests/Diff_hash_codes.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Linq;
+using NUnit.Framework;
+using ODiff.Tests.Fakes;
+
+namespace ODiff.Tests
+{
+    [TestFixture]
+    public class Diff_hash_codes
+    {
+        [Test]
+        public void It_will_report_diff_when_subobject_hash_codes_are_equal()
+        {
+            int hts1 = new TimeSpan(65536L).GetHashCode();
+            int hts2 = new TimeSpan(65536L).GetHashCode();
+            Assert.IsTrue(hts1 == hts2);
+
+            object o1 = new {
+                A = "MyA",
+                B = new TimeSpan(65536L),
+                C = new TimeSpan(65536L)
+            };
+            object o2 = new {
+                A = "MyB",
+                B = new TimeSpan(65536L),
+                C = new TimeSpan(65536L)
+            };
+
+            Assert.IsTrue(Diff.ObjectValues(o1, o2, new DiffConfig() { AllowCyclicGraph = true }).DiffFound);
+        }
+
+        [Test]
+        public void It_will_report_diff_when_subsubobject_hash_codes_are_equal()
+        {
+            int hts1 = new TimeRange(32768L, 65536L).GetHashCode();
+            int hts2 = new TimeRange(32768L, 65536L).GetHashCode();
+            Assert.IsFalse(hts1 == hts2);
+
+            object o1 = new
+            {
+                A = "MyA",
+                B = new TimeRange(32768L, 65536L),
+                C = new TimeRange(32768L, 65536L)
+            };
+            object o2 = new
+            {
+                A = "MyB",
+                B = new TimeRange(32768L, 65536L),
+                C = new TimeRange(32768L, 65536L)
+            };
+
+            Assert.IsTrue(Diff.ObjectValues(o1, o2, new DiffConfig() { AllowCyclicGraph = true }).DiffFound);
+        }
+
+        public class TimeRange
+        {
+            public TimeSpan Start;
+            public TimeSpan End;
+            public TimeRange(long start, long end)
+            {
+                Start = new TimeSpan(start);
+                End = new TimeSpan(end);
+            }
+        }
+    }
+}

--- a/ODiff.Tests/ODiff.Tests.csproj
+++ b/ODiff.Tests/ODiff.Tests.csproj
@@ -85,6 +85,7 @@
     <Compile Include="Diff_arrays.cs" />
     <Compile Include="Diff_complex_object_graphs.cs" />
     <Compile Include="DiffReportTableTests.cs" />
+    <Compile Include="Diff_hash_codes.cs" />
     <Compile Include="Diff_structs.cs" />
     <Compile Include="DSL.cs" />
     <Compile Include="Fakes\FakeData.cs" />

--- a/ODiff/Diff.cs
+++ b/ODiff/Diff.cs
@@ -10,10 +10,11 @@ namespace ODiff
         /// </summary>
         /// <param name="left"></param>
         /// <param name="right"></param>
+        /// <param name="config"></param>
         /// <returns>Diff report with detailed info about differences.</returns>
-        public static DiffReport ObjectValues(object left, object right)
+        public static DiffReport ObjectValues(object left, object right, DiffConfig config = null)
         {
-            return new ObjectGraphDiff(left, right).Diff();
+            return new ObjectGraphDiff(left, right, config).Diff();
         }
 
         /// <summary>
@@ -31,7 +32,26 @@ namespace ODiff
         /// <returns></returns>
         public static DiffReport ObjectValues(object left, object right, params INodeInterceptor[] interceptors)
         {
-            return new ObjectGraphDiff(left, right, interceptors).Diff();
+            return new ObjectGraphDiff(left, right, null, interceptors).Diff();
+        }
+
+        /// <summary>
+        /// Compares public members (fields and properties) on two object
+        /// graphs.
+        /// 
+        /// This function lets you "rewrite" nodes in object graph. 
+        /// It's done by intercepting each node before they are compared. 
+        /// This can be used to make sure two lists have same sorting.
+        /// Look in the Interceptor namespace for default implementations. 
+        /// </summary>
+        /// <param name="left"></param>
+        /// <param name="right"></param>
+        /// <param name="config"></param>
+        /// <param name="interceptors"></param>
+        /// <returns></returns>
+        public static DiffReport ObjectValues(object left, object right, DiffConfig config, params INodeInterceptor[] interceptors)
+        {
+            return new ObjectGraphDiff(left, right, config, interceptors).Diff();
         }
     }
 }

--- a/ODiff/DiffConfig.cs
+++ b/ODiff/DiffConfig.cs
@@ -1,0 +1,12 @@
+﻿namespace ODiff
+{
+    public class DiffConfig
+    {
+        public bool AllowCyclicGraph { get; set; }
+
+        public DiffConfig()
+        {
+            AllowCyclicGraph = false;
+        }
+    }
+}

--- a/ODiff/ODiff.csproj
+++ b/ODiff/ODiff.csproj
@@ -81,6 +81,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Diff.cs" />
+    <Compile Include="DiffConfig.cs" />
     <Compile Include="DiffReport.cs" />
     <Compile Include="Extensions\FieldInfoExtentions.cs" />
     <Compile Include="Extensions\IEnumerableExtensions.cs" />

--- a/ODiff/ObjectGraphDiff.cs
+++ b/ODiff/ObjectGraphDiff.cs
@@ -12,14 +12,16 @@ namespace ODiff
         private readonly object leftRootNode;
         private readonly object rightRootNode;
         private readonly List<INodeInterceptor> nodeInterceptors = new List<INodeInterceptor>();
+        private readonly DiffConfig config;
         private readonly DiffReport report;
         private readonly HashSet<Object> visitedNodes = new HashSet<Object>();
 
-        public ObjectGraphDiff(Object leftRootNode, Object rightRootNode, params INodeInterceptor[] interceptors)
+        public ObjectGraphDiff(Object leftRootNode, Object rightRootNode, DiffConfig config, params INodeInterceptor[] interceptors)
         {
             report = NoDiffFound();
             this.rightRootNode = rightRootNode;
             this.leftRootNode = leftRootNode;
+            this.config = config;
             nodeInterceptors.AddRange(interceptors);
         }
 
@@ -40,7 +42,8 @@ namespace ODiff
                 return;
             }
 
-            CheckIfNodesHaveBeenVisited(memberPath, leftNode, rightNode);
+            if ((config == null) || (!config.AllowCyclicGraph))
+                CheckIfNodesHaveBeenVisited(memberPath, leftNode, rightNode);
 
             VisitLeafNodes(memberPath, leftNode, rightNode);
         }


### PR DESCRIPTION
- DiffConfig with AllowCyclicGraph enables improved control.
- Two tests illustrate the problems and test the solution.

Please note that this solution does not correct the underlying problem, namely that HasSet is perhaps not the best way to check if the same object is visited multiple times. Pinning objects and checking the pointer values might perhaps be a better way to go, but then you get unsafe code though.
